### PR TITLE
Replace LightGraphs.jl with Graphs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.3.5"
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 DataStructures = "0.18"
 Distances = "0.8, 0.9, 0.10"
-LightGraphs = "1.3"
+Graphs = "1.4"
 Reexport = "0.2, 1.0"
 julia = "1.5, 1.6, 1.7"
 

--- a/benchmark/bench_descent.jl
+++ b/benchmark/bench_descent.jl
@@ -2,7 +2,7 @@ module BenchDescent
 
 using NearestNeighborDescent
 using NearestNeighborDescent: local_join!, get_neighbors!
-using LightGraphs
+using Graphs
 using Distances
 using BenchmarkTools
 using Random

--- a/benchmark/bench_knn_graphs.jl
+++ b/benchmark/bench_knn_graphs.jl
@@ -1,7 +1,7 @@
 module BenchKNNGraphs
 
 using NearestNeighborDescent.KNNGraphs
-using LightGraphs
+using Graphs
 using Distances
 using BenchmarkTools
 using Random

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,7 +2,7 @@ using Pkg
 tempdir = mktempdir()
 Pkg.activate(tempdir)
 Pkg.develop(PackageSpec(path=joinpath(@__DIR__, "..")))
-Pkg.add(["BenchmarkTools", "PkgBenchmark", "Random", "Distances", "LightGraphs"])
+Pkg.add(["BenchmarkTools", "PkgBenchmark", "Random", "Distances", "Graphs"])
 Pkg.resolve()
 
 using NearestNeighborDescent

--- a/docs/src/examples/descent_iters.jl
+++ b/docs/src/examples/descent_iters.jl
@@ -1,6 +1,6 @@
 # print information over iterations of nndescent
 using NearestNeighborDescent
-using LightGraphs
+using Graphs
 using Distances
 using MLDatasets
 using Statistics

--- a/src/NearestNeighborDescent.jl
+++ b/src/NearestNeighborDescent.jl
@@ -2,7 +2,7 @@ module NearestNeighborDescent
 
 using DataStructures
 using Distances
-using LightGraphs
+using Graphs
 using Reexport
 
 include("knn_graph/KNNGraphs.jl")

--- a/src/knn_graph/KNNGraphs.jl
+++ b/src/knn_graph/KNNGraphs.jl
@@ -2,7 +2,7 @@ module KNNGraphs
 
 using DataStructures
 using Distances
-using LightGraphs
+using Graphs
 using SparseArrays
 
 include("abstract.jl")

--- a/src/knn_graph/abstract.jl
+++ b/src/knn_graph/abstract.jl
@@ -19,8 +19,8 @@ abstract type ApproximateKNNGraph{V<:Integer,
 # interface
 Base.eltype(::ApproximateKNNGraph{V}) where V = V
 # all knn graphs are directed
-LightGraphs.is_directed(::Type{<:ApproximateKNNGraph}) = true
-LightGraphs.is_directed(::ApproximateKNNGraph) = true
+Graphs.is_directed(::Type{<:ApproximateKNNGraph}) = true
+Graphs.is_directed(::ApproximateKNNGraph) = true
 
 """
     knn_diameter(g::ApproximateKNNGraph{V}, v::V)

--- a/src/knn_graph/heap_edge.jl
+++ b/src/knn_graph/heap_edge.jl
@@ -38,7 +38,7 @@ Base.eltype(e::HeapKNNGraphEdge{V}) where V = V
 
 @inline flag(e::HeapKNNGraphEdge) = e.flag
 @inline weight(e::HeapKNNGraphEdge) = e.weight
-# lightgraphs interface
-@inline LightGraphs.src(e::HeapKNNGraphEdge) = e.src
-@inline LightGraphs.dst(e::HeapKNNGraphEdge) = e.dst
-@inline LightGraphs.reverse(e::E) where {E <: HeapKNNGraphEdge} = E(dst(e), src(e), weight(e), flag(e))
+# graphs interface
+@inline Graphs.src(e::HeapKNNGraphEdge) = e.src
+@inline Graphs.dst(e::HeapKNNGraphEdge) = e.dst
+@inline Graphs.reverse(e::E) where {E <: HeapKNNGraphEdge} = E(dst(e), src(e), weight(e), flag(e))

--- a/src/knn_graph/threaded_heap_graph.jl
+++ b/src/knn_graph/threaded_heap_graph.jl
@@ -79,7 +79,7 @@ Similar to `inneighbors(g::HeapKNNGraph, v)`, except it acquires locks for the n
 as it iterates in order for this to be thread-safe.
 
 """
-@inline function LightGraphs.inneighbors(g::LockHeapKNNGraph{V}, v::V) where V
+@inline function Graphs.inneighbors(g::LockHeapKNNGraph{V}, v::V) where V
     neighbs = V[]
     for i in nv(g)
         lock(g.locks[i]) do
@@ -99,7 +99,7 @@ end
 Similar to `outneighbors(g::HeapKNNGraph, v)`, except locks the neighbor heap before collecting
 to make this thread-safe.
 """
-@inline function LightGraphs.outneighbors(g::LockHeapKNNGraph{V}, v::V) where V
+@inline function Graphs.outneighbors(g::LockHeapKNNGraph{V}, v::V) where V
     neighbs = lock(g.locks[v]) do
         dst.(g.heaps[v].valtree)
     end
@@ -111,7 +111,7 @@ end
 
 Similar to `add_edge!(g::HeapKNNGraph, e)`, but made thread-safe using locks.
 """
-function LightGraphs.add_edge!(g::LockHeapKNNGraph, e::HeapKNNGraphEdge)
+function Graphs.add_edge!(g::LockHeapKNNGraph, e::HeapKNNGraphEdge)
     # NOTE we can assume the invariants for heap knn graphs hold
     lock(g.locks[src(e)]) do
         if e < first(g.heaps[src(e)]) && !has_edge(g, src(e), dst(e))

--- a/test/knn_graph/heap_graph_tests.jl
+++ b/test/knn_graph/heap_graph_tests.jl
@@ -56,8 +56,8 @@
             @test is_valid_knn_graph(g)
         end
     end
-    @testset "LightGraphs interface tests" begin
-        # test LightGraphs interface methods exist on HeapKNNGraph, LockHeapKNNGraph
+    @testset "Graphs interface tests" begin
+        # test Graphs interface methods exist on HeapKNNGraph, LockHeapKNNGraph
         for GraphT in [HeapKNNGraph, LockHeapKNNGraph]
             for m in (edges, vertices, weights, edgetype, ne, nv, eltype)
                 @test hasmethod(m, (GraphT,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 # tests
 using NearestNeighborDescent
 using NearestNeighborDescent.KNNGraphs
-using LightGraphs
+using Graphs
 using DataStructures
 using Distances
 using Test


### PR DESCRIPTION
LightGraphs.jl has been archived (October 2021), but the development has continued in Graphs.jl.
Without this update, other packages can get stuck at old versions.

I have run tests locally for Graphs.jl v1.4.1 and v1.7.1 and they pass.