### PR TITLE
Simple workaround for threadid() issue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,9 @@
 name: CI
 on:
-  pull_request:
   push:
-    branches:
-      - master
-    tags: '*'
+    branches: [main, master]
+    tags: ["*"]
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -13,34 +12,39 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
-#          - 'nightly'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'min'
+#          - 'pre'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: 1
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/src/search.jl
+++ b/src/search.jl
@@ -22,7 +22,8 @@ function search(graph::G,
     # lists of candidates, sorted by distance
     candidates = [BinaryMaxHeap{Tuple{U, V, Bool}}() for _ in 1:length(queries)]
     # a set of seen candidates per thread
-    seen_sets = [BitVector(undef, length(data)) for _ in 1:Threads.maxthreadid()]
+    max_threads = @static VERSION >= v"1.9.0" ? Threads.maxthreadid() : Threads.nthreads()
+    seen_sets = [BitVector(undef, length(data)) for _ in 1:max_threads]
     Threads.@threads :static for i in eachindex(queries) # :static needed to use threadid()
         # zero out seen
         seen = seen_sets[Threads.threadid()]

--- a/src/search.jl
+++ b/src/search.jl
@@ -22,8 +22,8 @@ function search(graph::G,
     # lists of candidates, sorted by distance
     candidates = [BinaryMaxHeap{Tuple{U, V, Bool}}() for _ in 1:length(queries)]
     # a set of seen candidates per thread
-    seen_sets = [BitVector(undef, length(data)) for _ in 1:Threads.nthreads()]
-    Threads.@threads for i in eachindex(queries)
+    seen_sets = [BitVector(undef, length(data)) for _ in 1:Threads.maxthreadid()]
+    Threads.@threads :static for i in eachindex(queries) # :static needed to use threadid()
         # zero out seen
         seen = seen_sets[Threads.threadid()]
         seen .= false


### PR DESCRIPTION
Replace `Threads.nthreads()` with `Threads.maxthreadid()`. Use `Threads.@threads :static` to be able to use `Threads.threadid()`.

This is just a quick bug fix, a better solution should be implemented down the line.
But I think it would be good to get this in, since the `threadid` construct can yield incorrect results without this fix.

See also #31 and https://julialang.org/blog/2023/07/PSA-dont-use-threadid/.

I've also updated CI.yml to make it run, basing it on https://github.com/JuliaLang/Example.jl/blob/master/.github/workflows/ci.yml.
