### PR TITLE
Add DataStructures.jl v0.19 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 Distances = "0.8, 0.9, 0.10"
 Graphs = "1.4"
 Reexport = "0.2, 1.0"


### PR DESCRIPTION
This PR adds compat with DataStructures.jl v0.19.
A list of breaking changes in DataStructures.jl v0.19 can be found here:
https://github.com/JuliaCollections/DataStructures.jl/releases/tag/v0.19.0

My understanding is that it relates to `PriorityQueue`s and sorted containers only and that the breaking changes thus does not affect `NearestNeighborDescent`.

Side notes - it would be good to:
* Reenable the CompatHelper workflow in this repo
* Release a new patch version after this PR has been merged